### PR TITLE
also use "value" hash when using a websocket

### DIFF
--- a/lib/rock/webapp/tasks.rb
+++ b/lib/rock/webapp/tasks.rb
@@ -11,7 +11,7 @@ module Rock
                 ws = Faye::WebSocket.new(env)
 
                 listener = data_source.on_raw_data do |sample|
-                    if !ws.send(MultiJson.dump(sample.to_json_value(:special_float_values => :string)))
+                    if !ws.send(MultiJson.dump(Hash[:value => sample.to_json_value(:special_float_values => :string)]))
                         WebApp.warn "failed to send, closing connection"
                         ws.close
                         listener.stop


### PR DESCRIPTION
This fix creates a uniform api no matter if http:// or ws:// is used
